### PR TITLE
feat: 레시피 첫 조회 시 이미지 자동 생성 및 프론트 표시

### DIFF
--- a/backend/routers/recipes.py
+++ b/backend/routers/recipes.py
@@ -1,17 +1,23 @@
 import re
-from fastapi import APIRouter, HTTPException, Query
+import asyncio
+import time
+import logging
 from typing import Optional
 
+import httpx
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+from fastapi.responses import StreamingResponse, JSONResponse
+
+from backend.config import AI_SERVER_URL
 from backend.database import get_supabase
 from backend.models.schemas import (
     RecipeDetailResponse,
     RecipeIngredient,
     RecipeStep,
 )
-import time
-import asyncio
-from fastapi.responses import StreamingResponse, JSONResponse
 from backend.services.llm_service import generate_recipe_summary, generate_recipe_summary_stream
+
+logger = logging.getLogger("recipes")
 
 # ── 인메모리 요약 캐시 (recipe_id → summary 텍스트) ──
 # 프롬프트 변경 시 서버 재시작하면 자동 카시 초기화
@@ -33,6 +39,33 @@ def _cache_set(recipe_id: str, summary: str):
     _summary_cache_ts[recipe_id] = time.time()
 
 router = APIRouter(prefix="/recipes", tags=["Recipes"])
+
+
+async def _generate_and_save_recipe_image(
+    recipe_id: str,
+    food_name: str,
+    ingredients: list[str],
+    steps: list[str],
+):
+    """백그라운드에서 레시피 이미지 생성 후 DB에 저장."""
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                f"{AI_SERVER_URL}/generate-recipe-image",
+                json={
+                    "food_name": food_name,
+                    "ingredients": ", ".join(ingredients),
+                    "recipe_steps": steps,
+                },
+            )
+            resp.raise_for_status()
+            image_url = resp.json().get("image_url")
+
+        if image_url:
+            get_supabase().table("recipes").update({"image_url": image_url}).eq("id", recipe_id).execute()
+            logger.info(f"[recipe image] saved for {recipe_id}")
+    except Exception as e:
+        logger.warning(f"[recipe image] generation failed for {recipe_id}: {e}")
 
 
 @router.get("/{recipe_id}/stream")
@@ -127,6 +160,7 @@ async def stream_recipe_summary(
 @router.get("/{recipe_id}", response_model=RecipeDetailResponse)
 async def get_recipe(
     recipe_id: str,
+    background_tasks: BackgroundTasks,
     breed_id: Optional[str] = Query(None, description="품종 ID (LLM 안내 생성용)"),
 ):
     db = get_supabase()
@@ -275,6 +309,17 @@ async def get_recipe(
             if found and llm_cal_total > 0:
                 calories_by_size = llm_cal_total
 
+    # ── 이미지 없으면 백그라운드에서 생성 (첫 조회 시 1회만) ──
+    image_url = recipe.get("image_url")
+    if not image_url and steps:
+        background_tasks.add_task(
+            _generate_and_save_recipe_image,
+            recipe_id=recipe["id"],
+            food_name=title,
+            ingredients=[ing.name for ing in ingredients],
+            steps=[s.instruction for s in steps],
+        )
+
     return RecipeDetailResponse(
         recipe_id=recipe["id"],
         title=title,
@@ -283,7 +328,7 @@ async def get_recipe(
         cook_time_min=recipe.get("cook_time_min"),
         difficulty=recipe.get("difficulty"),
         servings=recipe.get("servings", 1),
-        image_url=recipe.get("image_url"),
+        image_url=image_url,
         source_name=recipe.get("source_name"),
         source_url=recipe.get("source_url"),
         ingredients=ingredients,

--- a/frontend/src/screens/RecipeDetailScreen.tsx
+++ b/frontend/src/screens/RecipeDetailScreen.tsx
@@ -5,7 +5,7 @@
 // - 하단 버튼 sticky 고정
 // ============================================================
 import { useEffect, useState, useRef } from "react";
-import { View, Text, ScrollView, Pressable, LayoutAnimation, Platform, UIManager } from "react-native";
+import { View, Text, ScrollView, Pressable, LayoutAnimation, Platform, UIManager, Image } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "../navigation/RootStack";
@@ -332,7 +332,7 @@ const RecipeDetailScreen = ({ navigation, route }: Props) => {
         }}
         showsVerticalScrollIndicator={false}
       >
-        {/* ① 제목 + 유전병 태그 */}
+        {/* ① 제목 */}
         <View style={{ gap: 8, alignItems: "center" }}>
           <Text
             style={{
@@ -346,7 +346,33 @@ const RecipeDetailScreen = ({ navigation, route }: Props) => {
           </Text>
         </View>
 
-        {/* ② 메타 정보 */}
+        {/* ② 레시피 이미지 */}
+        {recipe.image_url ? (
+          <Image
+            source={{ uri: recipe.image_url }}
+            style={{ width: "100%", height: 220, borderRadius: 16 }}
+            resizeMode="cover"
+          />
+        ) : (
+          <View
+            style={{
+              width: "100%",
+              height: 220,
+              borderRadius: 16,
+              backgroundColor: "#f3f4f6",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 8,
+            }}
+          >
+            <Text style={{ fontSize: 36 }}>🍳</Text>
+            <Text style={{ fontSize: 13, color: "#9ca3af" }}>
+              이미지 준비 중...
+            </Text>
+          </View>
+        )}
+
+        {/* ③ 메타 정보 */}
         <View style={{ flexDirection: "row", gap: 8 }}>
           <MetaItem
             icon="⏱"
@@ -372,7 +398,7 @@ const RecipeDetailScreen = ({ navigation, route }: Props) => {
           <MetaItem icon="🍽" label="인분" value={`${recipe.servings}인분`} />
         </View>
 
-        {/* ③ 재료 (접기/펼치기, 중복 제거) */}
+        {/* ④ 재료 (접기/펼치기, 중복 제거) */}
         {uniqueIngredients.length > 0 && (
           <CollapsibleSection title="재료" defaultOpen={true}>
             <View style={{ gap: 6 }}>
@@ -434,7 +460,7 @@ const RecipeDetailScreen = ({ navigation, route }: Props) => {
           </CollapsibleSection>
         )}
 
-        {/* ④ 조리 순서 (접기/펼치기) */}
+        {/* ⑤ 조리 순서 (접기/펼치기) */}
         {recipe.steps.length > 0 && (
           <CollapsibleSection title="조리 순서" defaultOpen={true}>
             <View style={{ gap: 8 }}>
@@ -491,7 +517,7 @@ const RecipeDetailScreen = ({ navigation, route }: Props) => {
           </CollapsibleSection>
         )}
 
-        {/* ⑤ AI 가이드 - 스트리밍 */}
+        {/* ⑥ AI 가이드 - 스트리밍 */}
         <StreamingAiGuide
           recipeId={recipeId}
           breedId={breedId}


### PR DESCRIPTION
- backend: GET /recipes/{id} 에서 image_url 없으면 백그라운드로 AI 서비스 호출 후 DB 저장
- frontend: RecipeDetailScreen에 레시피 이미지 표시 추가, 생성 전 플레이스홀더 표시